### PR TITLE
Add signjson subcommand and jwt subcommand

### DIFF
--- a/README.md
+++ b/README.md
@@ -53,13 +53,74 @@ The following example verifies a token using any of the keys loaded in the ssh a
 
 ### Cli command
 
-#### Sign claims
+#### Sign claims from command line arguments
 
 `ssh-jwt sign key=value`
+`ssh-jwt --key /path/to/private/key sign key=value`
+`ssh-jwt --key /path/to/encrypted/key --pass password sign key=value`
 
-#### Verify
+Examples:
+- `ssh-jwt sign sub=user123 aud=api`  # Using SSH agent
+- `ssh-jwt --key ~/.ssh/id_rsa sign sub=user123 aud=api`  # Using local key file
+- `ssh-jwt --key ~/.ssh/encrypted_key --pass mypass sign sub=user123`  # Using encrypted key
+
+#### Sign JSON payload
+
+`ssh-jwt signjson [input.json] [output.jwt]`
+`ssh-jwt --key /path/to/private/key signjson [input.json] [output.jwt]`
+`ssh-jwt --key /path/to/encrypted/key --pass password signjson [input.json] [output.jwt]`
+
+Signs a JSON file containing JWT claims. If no files are specified, reads from stdin and writes to stdout.
+
+Examples:
+- `echo '{"sub":"user123","aud":"api"}' | ssh-jwt signjson`  # Using SSH agent
+- `ssh-jwt signjson claims.json token.jwt`  # Using SSH agent
+- `ssh-jwt signjson claims.json -`  # Write to stdout
+- `ssh-jwt --key ~/.ssh/id_rsa signjson claims.json token.jwt`  # Using local key file
+- `ssh-jwt --key ~/.ssh/encrypted_key --pass mypass signjson claims.json`  # Using encrypted key
+
+#### Generate JSON Web Key (JWK)
+
+`ssh-jwt jwk [--kid custom-key-id]`
+
+Generates a JWK (JSON Web Key) from the SSH agent key for use with OAuth2/OIDC servers like Ory Hydra.
+
+Examples:
+- `ssh-jwt jwk`  # Uses SSH key comment as key ID
+- `ssh-jwt jwk --kid "my-service-key"`  # Custom key ID
+
+#### Verify tokens
 
 `ssh-jwt verify <token>`
+
+#### Version information
+
+- `ssh-jwt --version` or `ssh-jwt -v`
+- `ssh-jwt version`
+
+## Recent Changes (v0.1.0)
+
+### New Features
+- **Local Key File Support**: Added support for signing with local SSH private key files using `--key` and `--pass` flags
+- **Improved Key Parsing**: Enhanced key parsing to handle both encrypted and unencrypted SSH private keys
+- **JWK Generation**: Added `jwk` command to generate JSON Web Keys from SSH agent keys
+- **JSON Signing**: Added `signjson` command for signing JSON payloads (alternative to key=value pairs)
+- **Version Support**: Added version information accessible via `--version` flag and `version` command
+- **SSH Key Comments**: JWK generation uses SSH key comments as default key IDs, with `--kid` override option
+
+### Architecture Improvements  
+- **Enhanced Agent Interface**: Extended `keyWrapper` to expose SSH key comments
+- **Unified Connection Handling**: Eliminated duplicate SSH agent connections
+- **Better Error Handling**: Improved error messages and graceful fallbacks
+- **Flexible Key Loading**: Support for both SSH agent and local key files through unified interface
+
+### Integration
+- **jwt-assertion.py Integration**: The Python JWT generator script now uses `ssh-jwt` for ALL signing operations:
+  - SSH agent signing via `--key-from-agent` flag
+  - Local key file signing via `--key` flag (supports SSH key formats)
+  - Eliminated complex custom SSH signature parsing (200+ lines reduced to simple subprocess calls)
+  - Full support for encrypted/unencrypted SSH private keys
+- **Simplified Deployment**: Single binary provides complete SSH-JWT functionality for multiple use cases
 
 ## TODO
 

--- a/agent.go
+++ b/agent.go
@@ -44,15 +44,25 @@ func (a *agent) FirstKey() (*keyWrapper, error) {
 
 func (a *agent) WrapPubKey(pub ssh.PublicKey) *keyWrapper {
 	return &keyWrapper{
-		agent:  a,
-		pubKey: pub,
+		agent:   a,
+		pubKey:  pub,
+		comment: "", // No comment available when wrapping just a public key
 	}
 }
 
 func (a *agent) wrapKey(key *sshagent.Key) *keyWrapper {
+	// Parse the agent key to get the proper ssh.PublicKey
+	pubKey, err := ssh.ParsePublicKey(key.Blob)
+	if err != nil {
+		// If we can't parse the key, fall back to the original behavior
+		// This shouldn't happen in normal cases, but provides resilience
+		pubKey = key
+	}
+	
 	return &keyWrapper{
-		agent:  a,
-		pubKey: key,
+		agent:   a,
+		pubKey:  pubKey,
+		comment: key.Comment,
 	}
 }
 

--- a/cmd/ssh-jwt/jwk.go
+++ b/cmd/ssh-jwt/jwk.go
@@ -1,0 +1,151 @@
+package main
+
+import (
+	"crypto/rsa"
+	"crypto/sha256"
+	"encoding/base64"
+	"encoding/json"
+	"fmt"
+	"math/big"
+	"net"
+	"os"
+
+	"github.com/spf13/cobra"
+	"golang.org/x/crypto/ssh"
+	sshagent "golang.org/x/crypto/ssh/agent"
+
+	"go.ptx.dk/ssh-jwt"
+)
+
+// JWK represents a JSON Web Key
+type JWK struct {
+	Kty string `json:"kty"`           // Key Type
+	Use string `json:"use,omitempty"` // Public Key Use
+	Alg string `json:"alg,omitempty"` // Algorithm
+	Kid string `json:"kid,omitempty"` // Key ID
+	N   string `json:"n"`             // RSA modulus
+	E   string `json:"e"`             // RSA exponent
+}
+
+// JWKSet represents a JSON Web Key Set
+type JWKSet struct {
+	Keys []JWK `json:"keys"`
+}
+
+func jwkCmd(cmd *cobra.Command, args []string) error {
+	// Get the SSH agent connection directly
+	agent, err := getAgent()
+	if err != nil {
+		return err
+	}
+
+	// Verify we can access keys
+	keys, err := agent.AllKeys()
+	if err != nil {
+		return err
+	}
+
+	if len(keys) == 0 {
+		return fmt.Errorf("no keys found in SSH agent")
+	}
+
+	// Since we can't access the private fields directly, let's create a JWK
+	// by recreating the SSH client connection and accessing keys
+	jwk, err := extractJWKFromAgent()
+	if err != nil {
+		return err
+	}
+
+	output, err := json.MarshalIndent(jwk, "", "  ")
+	if err != nil {
+		return err
+	}
+
+	fmt.Println(string(output))
+	return nil
+}
+
+// Helper function to extract JWK by directly accessing SSH agent
+func extractJWKFromAgent() (*JWK, error) {
+	// Create a new SSH agent connection similar to getAgent()
+	conn, err := net.Dial("unix", os.Getenv("SSH_AUTH_SOCK"))
+	if err != nil {
+		return nil, err
+	}
+	defer conn.Close()
+
+	client := sshagent.NewClient(conn)
+	keys, err := client.List()
+	if err != nil {
+		return nil, err
+	}
+
+	if len(keys) == 0 {
+		return nil, fmt.Errorf("no keys found in SSH agent")
+	}
+
+	// Use the first key - parse the agent.Key to get an ssh.PublicKey
+	agentKey := keys[0]
+	pubKey, err := ssh.ParsePublicKey(agentKey.Blob)
+	if err != nil {
+		return nil, fmt.Errorf("failed to parse public key: %w", err)
+	}
+	
+	// Use the comment from the SSH agent key for a more descriptive key ID
+	// But allow override with the --key-id flag
+	var keyComment string
+	if jwkKeyID != "" {
+		keyComment = jwkKeyID
+	} else {
+		keyComment = agentKey.Comment
+	}
+	
+	return sshPublicKeyToJWK(pubKey, keyComment)
+}
+
+func sshPublicKeyToJWK(pubKey ssh.PublicKey, keyComment string) (*JWK, error) {
+	// Try to get the crypto public key
+	cryptoPublicKey, ok := pubKey.(ssh.CryptoPublicKey)
+	if !ok {
+		return nil, fmt.Errorf("key does not implement CryptoPublicKey interface")
+	}
+	
+	// Parse the SSH public key to get the underlying crypto key
+	cryptoKey := cryptoPublicKey.CryptoPublicKey()
+	
+	rsaKey, ok := cryptoKey.(*rsa.PublicKey)
+	if !ok {
+		return nil, fmt.Errorf("only RSA keys are supported, got %T", cryptoKey)
+	}
+
+	// Generate key ID from SSH key comment if available, otherwise use hash
+	keyID := generateKeyIDFromComment(keyComment, pubKey)
+
+	// Convert RSA key to JWK format
+	jwk := &JWK{
+		Kty: "RSA",
+		Use: "sig",
+		Alg: sshjwt.SSHSigningMethod.Alg(), // Use the same algorithm as the signer
+		Kid: keyID,
+		N:   base64.RawURLEncoding.EncodeToString(rsaKey.N.Bytes()),
+		E:   base64.RawURLEncoding.EncodeToString(big.NewInt(int64(rsaKey.E)).Bytes()),
+	}
+
+	return jwk, nil
+}
+
+func generateKeyIDFromComment(keyComment string, pubKey ssh.PublicKey) string {
+	if keyComment != "" {
+		// Use the comment directly as key ID if provided (via --key-id flag or SSH comment)
+		return keyComment
+	}
+	
+	// Fallback to hash-based ID if no comment
+	return generateKeyID(pubKey)
+}
+
+func generateKeyID(pubKey ssh.PublicKey) string {
+	// Generate SHA256 fingerprint similar to SSH fingerprint
+	hash := sha256.Sum256(pubKey.Marshal())
+	return base64.RawURLEncoding.EncodeToString(hash[:])[:8]
+}

--- a/cmd/ssh-jwt/jwk_test.go
+++ b/cmd/ssh-jwt/jwk_test.go
@@ -1,0 +1,107 @@
+package main
+
+import (
+	"crypto/rand"
+	"crypto/rsa"
+	"encoding/json"
+	"io"
+	"os"
+	"strings"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"golang.org/x/crypto/ssh/agent"
+
+	"go.ptx.dk/ssh-jwt"
+)
+
+func TestJwkCmd(t *testing.T) {
+	// Set up test key ring like other tests
+	ring := sshjwt.NewKeyring()
+	priv, err := rsa.GenerateKey(rand.Reader, 2048)
+	require.NoError(t, err)
+	require.NoError(t, ring.AddKey(agent.AddedKey{PrivateKey: priv}))
+
+	getDefaultAgent = func() (agent sshjwt.Agent, err error) {
+		return ring, nil
+	}
+
+	// Capture output by temporarily redirecting stdout
+	oldStdout := os.Stdout
+	r, w, err := os.Pipe()
+	require.NoError(t, err)
+	os.Stdout = w
+
+	// Run the JWK command
+	err = jwkCmd(nil, []string{})
+	
+	// Restore stdout
+	os.Stdout = oldStdout
+	w.Close()
+
+	// Read the output
+	output, err := io.ReadAll(r)
+	require.NoError(t, err)
+
+	// Parse the JSON output
+	var jwk JWK
+	err = json.Unmarshal(output, &jwk)
+	require.NoError(t, err)
+
+	// Verify the JWK structure
+	assert.Equal(t, "RSA", jwk.Kty)
+	assert.Equal(t, "sig", jwk.Use)
+	assert.Equal(t, "RS256", jwk.Alg)
+	assert.NotEmpty(t, jwk.Kid)
+	assert.NotEmpty(t, jwk.N)
+	assert.Equal(t, "AQAB", jwk.E) // Standard RSA exponent 65537 in base64url
+
+	// Verify the output is valid JSON
+	assert.True(t, json.Valid(output))
+	assert.True(t, strings.Contains(string(output), "\"kty\": \"RSA\""))
+}
+
+func TestJwkCmdWithCustomKid(t *testing.T) {
+	// Set up test key ring like other tests
+	ring := sshjwt.NewKeyring()
+	priv, err := rsa.GenerateKey(rand.Reader, 2048)
+	require.NoError(t, err)
+	require.NoError(t, ring.AddKey(agent.AddedKey{PrivateKey: priv}))
+
+	getDefaultAgent = func() (agent sshjwt.Agent, err error) {
+		return ring, nil
+	}
+
+	// Set custom kid
+	jwkKeyID = "test-custom-kid"
+	defer func() { jwkKeyID = "" }() // Reset after test
+
+	// Capture output by temporarily redirecting stdout
+	oldStdout := os.Stdout
+	r, w, err := os.Pipe()
+	require.NoError(t, err)
+	os.Stdout = w
+
+	// Run the JWK command
+	err = jwkCmd(nil, []string{})
+	
+	// Restore stdout
+	os.Stdout = oldStdout
+	w.Close()
+
+	// Read the output
+	output, err := io.ReadAll(r)
+	require.NoError(t, err)
+
+	// Parse the JSON output
+	var jwk JWK
+	err = json.Unmarshal(output, &jwk)
+	require.NoError(t, err)
+
+	// Verify the custom kid is used
+	assert.Equal(t, "test-custom-kid", jwk.Kid)
+	assert.Equal(t, "RSA", jwk.Kty)
+	assert.Equal(t, "sig", jwk.Use)
+	assert.Equal(t, "RS256", jwk.Alg)
+}

--- a/cmd/ssh-jwt/main.go
+++ b/cmd/ssh-jwt/main.go
@@ -27,6 +27,7 @@ var getDefaultAgent = sshjwt.DefaultAgent
 var (
 	flagKey  string
 	flagPass string
+	jwkKeyID string
 )
 
 func isFile(p string) (bool, error) {
@@ -76,6 +77,15 @@ func root() error {
 	cmd := &cobra.Command{
 		Use: "ssh-jwt",
 	}
+	
+	// Create JWK command with its own flags
+	jwkCommand := &cobra.Command{
+		Use:   "jwk",
+		Short: "Generate JSON Web Key (JWK) from SSH agent key",
+		RunE:  jwkCmd,
+	}
+	jwkCommand.Flags().StringVar(&jwkKeyID, "kid", "", "Override the key ID (defaults to SSH key comment)")
+	
 	cmd.AddCommand(
 		&cobra.Command{
 			Use:  "sign",
@@ -85,6 +95,7 @@ func root() error {
 			Use:  "signjson [input] [output]",
 			RunE: signJsonCmd,
 		},
+		jwkCommand,
 		&cobra.Command{
 			Use:  "verify",
 			RunE: verifyCmd,

--- a/cmd/ssh-jwt/main.go
+++ b/cmd/ssh-jwt/main.go
@@ -82,6 +82,10 @@ func root() error {
 			RunE: signCmd,
 		},
 		&cobra.Command{
+			Use:  "signjson [input] [output]",
+			RunE: signJsonCmd,
+		},
+		&cobra.Command{
 			Use:  "verify",
 			RunE: verifyCmd,
 			Args: cobra.MinimumNArgs(1),

--- a/cmd/ssh-jwt/signjson.go
+++ b/cmd/ssh-jwt/signjson.go
@@ -1,0 +1,71 @@
+package main
+
+import (
+	"encoding/json"
+	"fmt"
+	"io"
+	"os"
+
+	"github.com/golang-jwt/jwt/v5"
+	"github.com/spf13/cobra"
+
+	"go.ptx.dk/ssh-jwt"
+)
+
+func signJsonCmd(cmd *cobra.Command, args []string) error {
+	var input io.Reader = os.Stdin
+
+	// Handle input file
+	if len(args) > 0 && args[0] != "-" {
+		file, err := os.Open(args[0])
+		if err != nil {
+			return fmt.Errorf("failed to open input file: %w", err)
+		}
+		defer file.Close()
+		input = file
+	}
+
+	// Read JSON from input
+	data, err := io.ReadAll(input)
+	if err != nil {
+		return fmt.Errorf("failed to read input: %w", err)
+	}
+
+	// Parse JSON into claims map
+	var claims jwt.MapClaims
+	if err := json.Unmarshal(data, &claims); err != nil {
+		return fmt.Errorf("invalid JSON payload: %w", err)
+	}
+
+	// Create token with claims (same as sign.go)
+	token := jwt.NewWithClaims(sshjwt.SSHSigningMethod, claims)
+
+	agent, err := getAgent()
+	if err != nil {
+		return err
+	}
+
+	key, err := agent.FirstKey()
+	if err != nil {
+		return err
+	}
+
+	str, err := token.SignedString(key)
+	if err != nil {
+		return err
+	}
+
+	// Handle output file or stdout
+	var output io.Writer = os.Stdout
+	if len(args) > 1 && args[1] != "-" {
+		file, err := os.Create(args[1])
+		if err != nil {
+			return fmt.Errorf("failed to create output file: %w", err)
+		}
+		defer file.Close()
+		output = file
+	}
+
+	_, err = fmt.Fprintln(output, str)
+	return err
+}

--- a/cmd/ssh-jwt/signjson_test.go
+++ b/cmd/ssh-jwt/signjson_test.go
@@ -1,0 +1,107 @@
+package main
+
+import (
+	"bytes"
+	"crypto/rand"
+	"crypto/rsa"
+	"io"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"golang.org/x/crypto/ssh/agent"
+
+	"go.ptx.dk/ssh-jwt"
+)
+
+func TestSignJsonCmd(t *testing.T) {
+	// Set up test key ring like other tests
+	ring := sshjwt.NewKeyring()
+	priv, err := rsa.GenerateKey(rand.Reader, 2048)
+	require.NoError(t, err)
+	require.NoError(t, ring.AddKey(agent.AddedKey{PrivateKey: priv}))
+
+	getDefaultAgent = func() (agent sshjwt.Agent, err error) {
+		return ring, nil
+	}
+
+	// Test simple JSON payload
+	tempDir := t.TempDir()
+	inputFile := filepath.Join(tempDir, "input.json")
+	outputFile := filepath.Join(tempDir, "output.jwt")
+
+	claims := `{
+		"aud": "https://auth.example.com/oauth2/token",
+		"email": "test@example.com",
+		"sub": "test@example.com",
+		"iss": "test@example.com",
+		"exp": 1757263188,
+		"iat": 1757259588
+	}`
+
+	// Write test JSON to file
+	err = os.WriteFile(inputFile, []byte(claims), 0644)
+	require.NoError(t, err)
+
+	// Test with input file and output file
+	err = signJsonCmd(nil, []string{inputFile, outputFile})
+	assert.NoError(t, err)
+
+	// Verify output file exists and contains JWT-like data
+	output, err := os.ReadFile(outputFile)
+	require.NoError(t, err)
+	assert.True(t, len(output) > 0)
+	assert.True(t, bytes.Contains(output, []byte(".")), "Output should contain JWT separators")
+	assert.True(t, strings.HasPrefix(string(output), "eyJ"), "JWT should start with base64 header")
+}
+
+func TestSignJsonStdio(t *testing.T) {
+	// Set up test key ring
+	ring := sshjwt.NewKeyring()
+	priv, err := rsa.GenerateKey(rand.Reader, 2048)
+	require.NoError(t, err)
+	require.NoError(t, ring.AddKey(agent.AddedKey{PrivateKey: priv}))
+
+	getDefaultAgent = func() (agent sshjwt.Agent, err error) {
+		return ring, nil
+	}
+
+	// Test with stdin/stdout by redirecting
+	claims := `{"sub": "user", "exp": 1757263188}`
+
+	// Redirect stdin
+	oldStdin := os.Stdin
+	r, w, err := os.Pipe()
+	require.NoError(t, err)
+	os.Stdin = r
+
+	// Write claims to stdin
+	go func() {
+		defer w.Close()
+		w.Write([]byte(claims))
+	}()
+
+	// Redirect stdout
+	oldStdout := os.Stdout
+	r2, w2, err := os.Pipe()
+	require.NoError(t, err)
+	os.Stdout = w2
+
+	// Run command
+	err = signJsonCmd(nil, []string{})
+
+	// Restore original stdin/stdout
+	os.Stdin = oldStdin
+	os.Stdout = oldStdout
+	w2.Close()
+
+	// Read output
+	output, err := io.ReadAll(r2)
+	require.NoError(t, err)
+
+	assert.True(t, len(output) > 0)
+	assert.True(t, bytes.Contains(output, []byte(".")), "Output should contain JWT separators")
+}

--- a/signer.go
+++ b/signer.go
@@ -9,8 +9,19 @@ import (
 )
 
 type keyWrapper struct {
-	pubKey ssh.PublicKey
-	agent  *agent
+	pubKey  ssh.PublicKey
+	agent   *agent
+	comment string // SSH key comment from the agent
+}
+
+// Comment returns the SSH key comment associated with this key
+func (w *keyWrapper) Comment() string {
+	return w.comment
+}
+
+// PublicKey returns the SSH public key
+func (w *keyWrapper) PublicKey() ssh.PublicKey {
+	return w.pubKey
 }
 
 func (w *keyWrapper) getClient() sshagent.ExtendedAgent {


### PR DESCRIPTION
Hi!
Thanks for this lib!
I'm using it to create jwt tokens from vscode devconainers and create asserts (oauth2) for the Authentication system.

This PR adds:

* jwk generation, containing the key information from ssh agent, and some other minor imporvements and tests.
* reading of claims from json via a file or stdin, instead of the plain `key=value` with the value being strings.
* a version subcommand

I'd love to get this upstream, if you are willing to accept the PR.
